### PR TITLE
Set ifi_change in link message

### DIFF
--- a/lib/route/link.c
+++ b/lib/route/link.c
@@ -1465,6 +1465,7 @@ int rtnl_link_build_change_request(struct rtnl_link *orig,
 	if (changes->ce_mask & LINK_ATTR_FLAGS) {
 		ifi.ifi_flags = orig->l_flags & ~changes->l_flag_mask;
 		ifi.ifi_flags |= changes->l_flags;
+		ifi.ifi_change = changes->l_flag_mask;
 	}
 
 	if (changes->l_family && changes->l_family != orig->l_family) {


### PR DESCRIPTION
The ifi_change field can be set with the mask of the flags that need to be changed as part of the link message to the kernel. This means only the specific flags that have been changed will be modified in the kernel, rather than the entire flags entry.